### PR TITLE
feat(api): implement OPDS 1.2 catalog with basic auth and navigation

### DIFF
--- a/sake/src/lib/server/auth/requestAccess.ts
+++ b/sake/src/lib/server/auth/requestAccess.ts
@@ -51,6 +51,10 @@ export function isPublicApiRoute(pathname: string, method: string): boolean {
 		return method === 'GET';
 	}
 
+	if (pathname === '/api/opds' || pathname.startsWith('/api/opds/')) {
+                return method === 'GET';
+	}
+
 	return false;
 }
 

--- a/sake/src/routes/api/opds/+server.ts
+++ b/sake/src/routes/api/opds/+server.ts
@@ -1,0 +1,94 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireBasicAuth } from "./auth";
+import { renderNavigationFeed } from "./feedBuilder";
+import { errorResponse } from "$lib/server/http/api";
+import { getRequestLogger } from "$lib/server/http/requestLogger";
+
+export const GET: RequestHandler = async (event) => {
+  const authResponse = await requireBasicAuth(event);
+  if (authResponse) return authResponse;
+
+  const { locals, url } = event;
+  const requestLogger = getRequestLogger(locals);
+
+  try {
+    const selfUrl = `/api/opds`;
+
+    const entries = [
+      {
+        title: "All Books (Alphabetical)",
+        id: "urn:sake:opds:alphabetical",
+        url: `alphabetical`,
+        description:
+          "All books in the library, sorted alphabetically by title.",
+      },
+      {
+        title: "Random Books",
+        id: "urn:sake:opds:random",
+        url: `random`,
+        description: "Browse random books.",
+      },
+      {
+        title: "Read Books",
+        id: "urn:sake:opds:read",
+        url: `read`,
+        description: "Browse read books.",
+      },
+      {
+        title: "Unread Books",
+        id: "urn:sake:opds:unread",
+        url: `unread`,
+        description: "Browse unread books.",
+      },
+      {
+        title: "Authors",
+        id: "urn:sake:opds:authors",
+        url: `authors`,
+        description: "Browse books by author.",
+      },
+      {
+        title: "Series",
+        id: "urn:sake:opds:series",
+        url: `series`,
+        description: "Browse books by series.",
+      },
+      {
+        title: "Publishers",
+        id: "urn:sake:opds:publishers",
+        url: `publishers`,
+        description: "Browse books by publisher.",
+      },
+      {
+        title: "Languages",
+        id: "urn:sake:opds:languages",
+        url: `languages`,
+        description: "Browse books by language.",
+      },
+      {
+        title: "Shelves",
+        id: "urn:sake:opds:shelves",
+        url: `shelves`,
+        description: "Browse books by shelf.",
+      },
+    ];
+
+    const xml = renderNavigationFeed(
+      "Sake OPDS Catalog",
+      "urn:sake:opds:root",
+      entries,
+      selfUrl,
+    );
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/atom+xml;charset=utf-8",
+      },
+    });
+  } catch (err: unknown) {
+    requestLogger.error(
+      { event: "opds.feed.failed", error: err },
+      "Failed to generate OPDS feed",
+    );
+    return errorResponse("Internal Server Error", 500);
+  }
+};

--- a/sake/src/routes/api/opds/alphabetical/+server.ts
+++ b/sake/src/routes/api/opds/alphabetical/+server.ts
@@ -1,0 +1,42 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { requireBasicAuth } from '../auth';
+import { listLibraryUseCase } from '$lib/server/application/composition';
+import { renderAcquisitionFeed } from '../feedBuilder';
+import { errorResponse } from '$lib/server/http/api';
+import { getRequestLogger } from '$lib/server/http/requestLogger';
+
+export const GET: RequestHandler = async (event) => {
+	const authResponse = await requireBasicAuth(event);
+	if (authResponse) return authResponse;
+
+	const { locals, url } = event;
+	const requestLogger = getRequestLogger(locals);
+
+	try {
+		const result = await listLibraryUseCase.execute();
+		if (!result.ok) {
+			return errorResponse(result.error.message, result.error.status);
+		}
+
+		// Sort books alphabetically by title
+		const books = result.value.books.sort((a, b) => a.title.localeCompare(b.title));
+		
+		const selfUrl = `/api/opds/alphabetical`;
+
+		const xml = renderAcquisitionFeed(
+			'All Books (Alphabetical)',
+			'urn:sake:opds:alphabetical',
+			books,
+			selfUrl
+		);
+
+		return new Response(xml, {
+			headers: {
+				'Content-Type': 'application/atom+xml;charset=utf-8'
+			}
+		});
+	} catch (err: unknown) {
+		requestLogger.error({ event: 'opds.alphabetical.failed', error: err }, 'Failed to generate alphabetical feed');
+		return errorResponse('Internal Server Error', 500);
+	}
+};

--- a/sake/src/routes/api/opds/alphabetical/+server.ts
+++ b/sake/src/routes/api/opds/alphabetical/+server.ts
@@ -1,42 +1,46 @@
-import type { RequestHandler } from '@sveltejs/kit';
-import { requireBasicAuth } from '../auth';
-import { listLibraryUseCase } from '$lib/server/application/composition';
-import { renderAcquisitionFeed } from '../feedBuilder';
-import { errorResponse } from '$lib/server/http/api';
-import { getRequestLogger } from '$lib/server/http/requestLogger';
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireBasicAuth } from "../auth";
+import { listLibraryUseCase } from "$lib/server/application/composition";
+import { renderAcquisitionFeed } from "../feedBuilder";
+import { errorResponse } from "$lib/server/http/api";
+import { getRequestLogger } from "$lib/server/http/requestLogger";
 
 export const GET: RequestHandler = async (event) => {
-	const authResponse = await requireBasicAuth(event);
-	if (authResponse) return authResponse;
+  const authResponse = await requireBasicAuth(event);
+  if (authResponse) return authResponse;
 
-	const { locals, url } = event;
-	const requestLogger = getRequestLogger(locals);
+  const { locals, url } = event;
+  const requestLogger = getRequestLogger(locals);
 
-	try {
-		const result = await listLibraryUseCase.execute();
-		if (!result.ok) {
-			return errorResponse(result.error.message, result.error.status);
-		}
+  try {
+    const result = await listLibraryUseCase.execute();
+    if (!result.ok) {
+      return errorResponse(result.error.message, result.error.status);
+    }
 
-		// Sort books alphabetically by title
-		const books = result.value.books.sort((a, b) => a.title.localeCompare(b.title));
-		
-		const selfUrl = `/api/opds/alphabetical`;
+    const books = result.value.books.sort((a, b) =>
+      a.title.localeCompare(b.title),
+    );
 
-		const xml = renderAcquisitionFeed(
-			'All Books (Alphabetical)',
-			'urn:sake:opds:alphabetical',
-			books,
-			selfUrl
-		);
+    const selfUrl = `/api/opds/alphabetical`;
 
-		return new Response(xml, {
-			headers: {
-				'Content-Type': 'application/atom+xml;charset=utf-8'
-			}
-		});
-	} catch (err: unknown) {
-		requestLogger.error({ event: 'opds.alphabetical.failed', error: err }, 'Failed to generate alphabetical feed');
-		return errorResponse('Internal Server Error', 500);
-	}
+    const xml = renderAcquisitionFeed(
+      "All Books (Alphabetical)",
+      "urn:sake:opds:alphabetical",
+      books,
+      selfUrl,
+    );
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/atom+xml;charset=utf-8",
+      },
+    });
+  } catch (err: unknown) {
+    requestLogger.error(
+      { event: "opds.alphabetical.failed", error: err },
+      "Failed to generate alphabetical feed",
+    );
+    return errorResponse("Internal Server Error", 500);
+  }
 };

--- a/sake/src/routes/api/opds/auth.ts
+++ b/sake/src/routes/api/opds/auth.ts
@@ -1,0 +1,56 @@
+import type { RequestEvent } from "@sveltejs/kit";
+import { userRepository } from "$lib/server/application/composition";
+import { verifyPassword } from "$lib/server/application/services/LocalAuthService";
+
+export async function requireBasicAuth(
+  event: RequestEvent,
+): Promise<Response | null> {
+  const authHeader = event.request.headers.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Basic ")) {
+    return new Response("Unauthorized", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": 'Basic realm="OPDS Catalog"',
+      },
+    });
+  }
+
+  const base64Credentials = authHeader.substring(6);
+  const credentials = Buffer.from(base64Credentials, "base64").toString(
+    "utf-8",
+  );
+  const [username, ...passwordParts] = credentials.split(":");
+  const password = passwordParts.join(":");
+
+  if (!username || !password) {
+    return new Response("Unauthorized", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": 'Basic realm="OPDS Catalog"',
+      },
+    });
+  }
+
+  const user = await userRepository.getByUsername(username);
+  if (!user || user.isDisabled) {
+    return new Response("Unauthorized", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": 'Basic realm="OPDS Catalog"',
+      },
+    });
+  }
+
+  const passwordMatches = await verifyPassword(password, user.passwordHash);
+  if (!passwordMatches) {
+    return new Response("Unauthorized", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": 'Basic realm="OPDS Catalog"',
+      },
+    });
+  }
+
+  // Authenticated successfully
+  return null;
+}

--- a/sake/src/routes/api/opds/authors/+server.ts
+++ b/sake/src/routes/api/opds/authors/+server.ts
@@ -20,7 +20,6 @@ export const GET: RequestHandler = async (event) => {
 
     const books = result.value.books;
 
-    // Get unique authors
     const authorsSet = new Set<string>();
     for (const book of books) {
       if (book.author) {

--- a/sake/src/routes/api/opds/authors/+server.ts
+++ b/sake/src/routes/api/opds/authors/+server.ts
@@ -1,0 +1,60 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireBasicAuth } from "../auth";
+import { listLibraryUseCase } from "$lib/server/application/composition";
+import { renderNavigationFeed } from "../feedBuilder";
+import { errorResponse } from "$lib/server/http/api";
+import { getRequestLogger } from "$lib/server/http/requestLogger";
+
+export const GET: RequestHandler = async (event) => {
+  const authResponse = await requireBasicAuth(event);
+  if (authResponse) return authResponse;
+
+  const { locals, url } = event;
+  const requestLogger = getRequestLogger(locals);
+
+  try {
+    const result = await listLibraryUseCase.execute();
+    if (!result.ok) {
+      return errorResponse(result.error.message, result.error.status);
+    }
+
+    const books = result.value.books;
+
+    // Get unique authors
+    const authorsSet = new Set<string>();
+    for (const book of books) {
+      if (book.author) {
+        authorsSet.add(book.author);
+      }
+    }
+
+    const authors = Array.from(authorsSet).sort();
+
+    const selfUrl = `/api/opds/authors`;
+
+    const entries = authors.map((author) => ({
+      title: author,
+      id: `urn:sake:opds:author:${encodeURIComponent(author)}`,
+      url: `${encodeURIComponent(author)}`,
+    }));
+
+    const xml = renderNavigationFeed(
+      "Authors",
+      "urn:sake:opds:authors",
+      entries,
+      selfUrl,
+    );
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/atom+xml;charset=utf-8",
+      },
+    });
+  } catch (err: unknown) {
+    requestLogger.error(
+      { event: "opds.authors.failed", error: err },
+      "Failed to generate authors feed",
+    );
+    return errorResponse("Internal Server Error", 500);
+  }
+};

--- a/sake/src/routes/api/opds/authors/[author]/+server.ts
+++ b/sake/src/routes/api/opds/authors/[author]/+server.ts
@@ -1,0 +1,48 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { requireBasicAuth } from '../../auth';
+import { listLibraryUseCase } from '$lib/server/application/composition';
+import { renderAcquisitionFeed } from '../../feedBuilder';
+import { errorResponse } from '$lib/server/http/api';
+import { getRequestLogger } from '$lib/server/http/requestLogger';
+
+export const GET: RequestHandler = async (event) => {
+	const authResponse = await requireBasicAuth(event);
+	if (authResponse) return authResponse;
+
+	const { params, locals, url } = event;
+	const requestLogger = getRequestLogger(locals);
+	const authorName = params.author;
+
+	if (!authorName) {
+		return errorResponse('Missing author parameter', 400);
+	}
+
+	try {
+		const result = await listLibraryUseCase.execute();
+		if (!result.ok) {
+			return errorResponse(result.error.message, result.error.status);
+		}
+
+		const books = result.value.books.filter(
+			(book) => book.author === authorName
+		).sort((a, b) => a.title.localeCompare(b.title));
+		
+		const selfUrl = `/api/opds/authors/${encodeURIComponent(authorName)}`;
+
+		const xml = renderAcquisitionFeed(
+			`Books by ${authorName}`,
+			`urn:sake:opds:author:${encodeURIComponent(authorName)}`,
+			books,
+			selfUrl
+		);
+
+		return new Response(xml, {
+			headers: {
+				'Content-Type': 'application/atom+xml;charset=utf-8'
+			}
+		});
+	} catch (err: unknown) {
+		requestLogger.error({ event: 'opds.author.books.failed', error: err }, 'Failed to generate author books feed');
+		return errorResponse('Internal Server Error', 500);
+	}
+};

--- a/sake/src/routes/api/opds/covers/[fileName]/+server.ts
+++ b/sake/src/routes/api/opds/covers/[fileName]/+server.ts
@@ -1,0 +1,50 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { requireBasicAuth } from '../../auth';
+import { getLibraryCoverUseCase } from '$lib/server/application/composition';
+import { errorResponse } from '$lib/server/http/api';
+import { getRequestLogger } from '$lib/server/http/requestLogger';
+import { toLogError } from '$lib/server/infrastructure/logging/logger';
+
+export const GET: RequestHandler = async (event) => {
+	const authResponse = await requireBasicAuth(event);
+	if (authResponse) return authResponse;
+
+	const { params, locals } = event;
+	const requestLogger = getRequestLogger(locals);
+	const fileName = params.fileName;
+	
+	if (!fileName) {
+		requestLogger.warn({ event: 'opds.cover.fetch.validation_failed' }, 'Missing file name parameter');
+		return errorResponse('Missing file name parameter', 400);
+	}
+
+	try {
+		const result = await getLibraryCoverUseCase.execute(fileName);
+		if (!result.ok) {
+			requestLogger.warn(
+				{
+					event: 'opds.cover.fetch.use_case_failed',
+					fileName,
+					statusCode: result.error.status,
+					reason: result.error.message
+				},
+				'Fetch library cover rejected'
+			);
+			return errorResponse(result.error.message, result.error.status);
+		}
+
+		return new Response(result.value.data, {
+			headers: {
+				'Cache-Control': result.value.cacheControl,
+				'Content-Length': result.value.contentLength.toString(),
+				'Content-Type': result.value.contentType
+			}
+		});
+	} catch (err: unknown) {
+		requestLogger.error(
+			{ event: 'opds.cover.fetch.failed', error: toLogError(err), fileName },
+			'Fetch library cover failed'
+		);
+		return errorResponse('Cover not found', 404);
+	}
+};

--- a/sake/src/routes/api/opds/download/[title]/+server.ts
+++ b/sake/src/routes/api/opds/download/[title]/+server.ts
@@ -1,0 +1,46 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { requireBasicAuth } from '../../auth';
+import { getLibraryFileUseCase } from '$lib/server/application/composition';
+import { errorResponse } from '$lib/server/http/api';
+import { getRequestLogger } from '$lib/server/http/requestLogger';
+import { toLogError } from '$lib/server/infrastructure/logging/logger';
+
+export const GET: RequestHandler = async (event) => {
+	const authResponse = await requireBasicAuth(event);
+	if (authResponse) return authResponse;
+
+	const { params, locals } = event;
+	const requestLogger = getRequestLogger(locals);
+	const title = params.title;
+	
+	if (!title) {
+		requestLogger.warn({ event: 'opds.file.fetch.validation_failed' }, 'Missing title parameter');
+		return errorResponse('Missing title parameter', 400);
+	}
+
+	try {
+		const result = await getLibraryFileUseCase.execute(title);
+		if (!result.ok) {
+			requestLogger.warn(
+				{
+					event: 'opds.file.fetch.use_case_failed',
+					title,
+					statusCode: result.error.status,
+					reason: result.error.message
+				},
+				'Fetch library file rejected'
+			);
+			return errorResponse(result.error.message, result.error.status);
+		}
+
+		return new Response(result.value.data, {
+			headers: {
+				'Content-Type': result.value.contentType,
+				'Content-Length': result.value.contentLength.toString()
+			}
+		});
+	} catch (err: unknown) {
+		requestLogger.error({ event: 'opds.file.fetch.failed', error: toLogError(err), title }, 'Fetch library file failed');
+		return errorResponse('File not found', 404);
+	}
+};

--- a/sake/src/routes/api/opds/feedBuilder.ts
+++ b/sake/src/routes/api/opds/feedBuilder.ts
@@ -38,13 +38,10 @@ export function renderAcquisitionFeed(
     let coverMimeType = mimeTypes.default;
 
     if (book.cover) {
-      // book.cover usually stores the full /api/library/covers/filename.jpg?v=123 route.
-      // We need to strip query params, get the actual filename, and re-append query params
-      // so it correctly routes through our OPDS endpoint without URL-encoding the '?v='
-      const parts = book.cover.split('?');
+      const parts = book.cover.split("?");
       const basePath = parts[0] || "";
       const queryParams = parts.length > 1 ? `?${parts[1]}` : "";
-      
+
       const filename = basePath.split("/").pop() || "";
       coverUrl = `/api/opds/covers/${encodeURIComponent(filename)}${queryParams}`;
 

--- a/sake/src/routes/api/opds/feedBuilder.ts
+++ b/sake/src/routes/api/opds/feedBuilder.ts
@@ -33,9 +33,25 @@ export function renderAcquisitionFeed(
 
   for (const book of books) {
     const bookUrl = `/api/opds/download/${encodeURIComponent(book.s3_storage_key)}`;
-    const coverUrl = book.cover
-      ? `/api/opds/covers/${encodeURIComponent(book.cover)}`
-      : null;
+
+    let coverUrl: string | null = null;
+    let coverMimeType = mimeTypes.default;
+
+    if (book.cover) {
+      // book.cover usually stores the full /api/library/covers/filename.jpg?v=123 route.
+      // We need to strip query params, get the actual filename, and re-append query params
+      // so it correctly routes through our OPDS endpoint without URL-encoding the '?v='
+      const parts = book.cover.split('?');
+      const basePath = parts[0] || "";
+      const queryParams = parts.length > 1 ? `?${parts[1]}` : "";
+      
+      const filename = basePath.split("/").pop() || "";
+      coverUrl = `/api/opds/covers/${encodeURIComponent(filename)}${queryParams}`;
+
+      const coverExt = filename.split(".").pop()?.toLowerCase() || "";
+      coverMimeType = mimeTypes[coverExt] || "image/jpeg";
+    }
+
     const mimeType =
       mimeTypes[book.extension?.toLowerCase() || ""] || mimeTypes.default;
     const bookUpdated = book.createdAt || now;
@@ -52,8 +68,8 @@ export function renderAcquisitionFeed(
 
     if (coverUrl) {
       xml += `
-    <link rel="http://opds-spec.org/image" href="${escapeXml(coverUrl)}" type="image/jpeg"/>
-    <link rel="http://opds-spec.org/image/thumbnail" href="${escapeXml(coverUrl)}" type="image/jpeg"/>`;
+    <link rel="http://opds-spec.org/image" href="${escapeXml(coverUrl)}" type="${escapeXml(coverMimeType)}"/>
+    <link rel="http://opds-spec.org/image/thumbnail" href="${escapeXml(coverUrl)}" type="${escapeXml(coverMimeType)}"/>`;
     }
 
     xml += `

--- a/sake/src/routes/api/opds/feedBuilder.ts
+++ b/sake/src/routes/api/opds/feedBuilder.ts
@@ -1,0 +1,101 @@
+import type { Book } from "$lib/server/domain/entities/Book";
+import { mimeTypes } from "$lib/server/constants/mimeTypes";
+
+function escapeXml(value: string | null | undefined): string {
+  if (!value) return "";
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+export function renderAcquisitionFeed(
+  title: string,
+  feedId: string,
+  books: Book[],
+  selfUrl: string,
+): string {
+  const now = new Date().toISOString();
+
+  let xml = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:dc="http://purl.org/dc/terms/"
+      xmlns:opds="http://opds-spec.org/2010/catalog">
+  <id>${escapeXml(feedId)}</id>
+  <title>${escapeXml(title)}</title>
+  <updated>${now}</updated>
+  <author><name>Sake</name></author>
+  <link rel="self" href="${escapeXml(selfUrl)}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
+  <link rel="start" href="/api/opds" type="application/atom+xml;profile=opds-catalog;kind=navigation"/>
+`;
+
+  for (const book of books) {
+    const bookUrl = `/api/opds/download/${encodeURIComponent(book.s3_storage_key)}`;
+    const coverUrl = book.cover
+      ? `/api/opds/covers/${encodeURIComponent(book.cover)}`
+      : null;
+    const mimeType =
+      mimeTypes[book.extension?.toLowerCase() || ""] || mimeTypes.default;
+    const bookUpdated = book.createdAt || now;
+
+    xml += `  <entry>
+    <id>urn:sake:book:${book.id}</id>
+    <title>${escapeXml(book.title)}</title>
+    <updated>${bookUpdated}</updated>
+    <author><name>${escapeXml(book.author || "Unknown author")}</name></author>
+    ${book.language ? `<dc:language>${escapeXml(book.language)}</dc:language>` : ""}
+    ${book.publisher ? `<dc:publisher>${escapeXml(book.publisher)}</dc:publisher>` : ""}
+    <summary>${escapeXml(book.description || "")}</summary>
+    <link rel="http://opds-spec.org/acquisition" href="${escapeXml(bookUrl)}" type="${escapeXml(mimeType)}"/>`;
+
+    if (coverUrl) {
+      xml += `
+    <link rel="http://opds-spec.org/image" href="${escapeXml(coverUrl)}" type="image/jpeg"/>
+    <link rel="http://opds-spec.org/image/thumbnail" href="${escapeXml(coverUrl)}" type="image/jpeg"/>`;
+    }
+
+    xml += `
+  </entry>
+`;
+  }
+
+  xml += `</feed>`;
+  return xml;
+}
+
+export function renderNavigationFeed(
+  title: string,
+  feedId: string,
+  entries: { title: string; id: string; url: string; description?: string }[],
+  selfUrl: string,
+): string {
+  const now = new Date().toISOString();
+
+  let xml = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:dc="http://purl.org/dc/terms/"
+      xmlns:opds="http://opds-spec.org/2010/catalog">
+  <id>${escapeXml(feedId)}</id>
+  <title>${escapeXml(title)}</title>
+  <updated>${now}</updated>
+  <author><name>Sake</name></author>
+  <link rel="self" href="${escapeXml(selfUrl)}" type="application/atom+xml;profile=opds-catalog;kind=navigation"/>
+  <link rel="start" href="/api/opds" type="application/atom+xml;profile=opds-catalog;kind=navigation"/>
+`;
+
+  for (const entry of entries) {
+    xml += `  <entry>
+    <title>${escapeXml(entry.title)}</title>
+    <id>${escapeXml(entry.id)}</id>
+    <link rel="subsection" href="${escapeXml(selfUrl + "/" + entry.url)}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
+    ${entry.description ? `<summary>${escapeXml(entry.description)}</summary>` : ""}
+    <updated>${now}</updated>
+  </entry>
+`;
+  }
+
+  xml += `</feed>`;
+  return xml;
+}

--- a/sake/src/routes/api/opds/languages/+server.ts
+++ b/sake/src/routes/api/opds/languages/+server.ts
@@ -1,0 +1,60 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireBasicAuth } from "../auth";
+import { listLibraryUseCase } from "$lib/server/application/composition";
+import { renderNavigationFeed } from "../feedBuilder";
+import { errorResponse } from "$lib/server/http/api";
+import { getRequestLogger } from "$lib/server/http/requestLogger";
+
+export const GET: RequestHandler = async (event) => {
+  const authResponse = await requireBasicAuth(event);
+  if (authResponse) return authResponse;
+
+  const { locals } = event;
+  const requestLogger = getRequestLogger(locals);
+
+  try {
+    const result = await listLibraryUseCase.execute();
+    if (!result.ok) {
+      return errorResponse(result.error.message, result.error.status);
+    }
+
+    const books = result.value.books;
+
+    // Get unique languages
+    const languagesSet = new Set<string>();
+    for (const book of books) {
+      if (book.language) {
+        languagesSet.add(book.language);
+      }
+    }
+
+    const languages = Array.from(languagesSet).sort();
+
+    const selfUrl = `/api/opds/languages`;
+
+    const entries = languages.map((lang) => ({
+      title: lang.toUpperCase(),
+      id: `urn:sake:opds:language:${encodeURIComponent(lang)}`,
+      url: `${encodeURIComponent(lang)}`,
+    }));
+
+    const xml = renderNavigationFeed(
+      "Languages",
+      "urn:sake:opds:languages",
+      entries,
+      selfUrl,
+    );
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/atom+xml;charset=utf-8",
+      },
+    });
+  } catch (err: unknown) {
+    requestLogger.error(
+      { event: "opds.languages.failed", error: err },
+      "Failed to generate languages feed",
+    );
+    return errorResponse("Internal Server Error", 500);
+  }
+};

--- a/sake/src/routes/api/opds/languages/+server.ts
+++ b/sake/src/routes/api/opds/languages/+server.ts
@@ -20,7 +20,6 @@ export const GET: RequestHandler = async (event) => {
 
     const books = result.value.books;
 
-    // Get unique languages
     const languagesSet = new Set<string>();
     for (const book of books) {
       if (book.language) {

--- a/sake/src/routes/api/opds/languages/[language]/+server.ts
+++ b/sake/src/routes/api/opds/languages/[language]/+server.ts
@@ -1,0 +1,49 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { requireBasicAuth } from '../../auth';
+import { listLibraryUseCase } from '$lib/server/application/composition';
+import { renderAcquisitionFeed } from '../../feedBuilder';
+import { errorResponse } from '$lib/server/http/api';
+import { getRequestLogger } from '$lib/server/http/requestLogger';
+
+export const GET: RequestHandler = async (event) => {
+	const authResponse = await requireBasicAuth(event);
+	if (authResponse) return authResponse;
+
+	const { params, locals } = event;
+	const requestLogger = getRequestLogger(locals);
+	const languageCode = params.language;
+
+	if (!languageCode) {
+		return errorResponse('Missing language parameter', 400);
+	}
+
+	try {
+		const result = await listLibraryUseCase.execute();
+		if (!result.ok) {
+			return errorResponse(result.error.message, result.error.status);
+		}
+
+		// Filter by language and sort alphabetically
+		const books = result.value.books.filter(
+			(book) => book.language === languageCode
+		).sort((a, b) => a.title.localeCompare(b.title));
+		
+		const selfUrl = `/api/opds/languages/${encodeURIComponent(languageCode)}`;
+
+		const xml = renderAcquisitionFeed(
+			`Books in ${languageCode.toUpperCase()}`,
+			`urn:sake:opds:language:${encodeURIComponent(languageCode)}`,
+			books,
+			selfUrl
+		);
+
+		return new Response(xml, {
+			headers: {
+				'Content-Type': 'application/atom+xml;charset=utf-8'
+			}
+		});
+	} catch (err: unknown) {
+		requestLogger.error({ event: 'opds.language.books.failed', error: err }, 'Failed to generate language books feed');
+		return errorResponse('Internal Server Error', 500);
+	}
+};

--- a/sake/src/routes/api/opds/publishers/+server.ts
+++ b/sake/src/routes/api/opds/publishers/+server.ts
@@ -20,7 +20,6 @@ export const GET: RequestHandler = async (event) => {
 
     const books = result.value.books;
 
-    // Get unique publishers
     const publishersSet = new Set<string>();
     for (const book of books) {
       if (book.publisher) {

--- a/sake/src/routes/api/opds/publishers/+server.ts
+++ b/sake/src/routes/api/opds/publishers/+server.ts
@@ -1,0 +1,60 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireBasicAuth } from "../auth";
+import { listLibraryUseCase } from "$lib/server/application/composition";
+import { renderNavigationFeed } from "../feedBuilder";
+import { errorResponse } from "$lib/server/http/api";
+import { getRequestLogger } from "$lib/server/http/requestLogger";
+
+export const GET: RequestHandler = async (event) => {
+  const authResponse = await requireBasicAuth(event);
+  if (authResponse) return authResponse;
+
+  const { locals } = event;
+  const requestLogger = getRequestLogger(locals);
+
+  try {
+    const result = await listLibraryUseCase.execute();
+    if (!result.ok) {
+      return errorResponse(result.error.message, result.error.status);
+    }
+
+    const books = result.value.books;
+
+    // Get unique publishers
+    const publishersSet = new Set<string>();
+    for (const book of books) {
+      if (book.publisher) {
+        publishersSet.add(book.publisher);
+      }
+    }
+
+    const publishers = Array.from(publishersSet).sort();
+
+    const selfUrl = `/api/opds/publishers`;
+
+    const entries = publishers.map((pub) => ({
+      title: pub,
+      id: `urn:sake:opds:publisher:${encodeURIComponent(pub)}`,
+      url: `${encodeURIComponent(pub)}`,
+    }));
+
+    const xml = renderNavigationFeed(
+      "Publishers",
+      "urn:sake:opds:publishers",
+      entries,
+      selfUrl,
+    );
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/atom+xml;charset=utf-8",
+      },
+    });
+  } catch (err: unknown) {
+    requestLogger.error(
+      { event: "opds.publishers.failed", error: err },
+      "Failed to generate publishers feed",
+    );
+    return errorResponse("Internal Server Error", 500);
+  }
+};

--- a/sake/src/routes/api/opds/publishers/[publisher]/+server.ts
+++ b/sake/src/routes/api/opds/publishers/[publisher]/+server.ts
@@ -1,0 +1,49 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { requireBasicAuth } from '../../auth';
+import { listLibraryUseCase } from '$lib/server/application/composition';
+import { renderAcquisitionFeed } from '../../feedBuilder';
+import { errorResponse } from '$lib/server/http/api';
+import { getRequestLogger } from '$lib/server/http/requestLogger';
+
+export const GET: RequestHandler = async (event) => {
+	const authResponse = await requireBasicAuth(event);
+	if (authResponse) return authResponse;
+
+	const { params, locals } = event;
+	const requestLogger = getRequestLogger(locals);
+	const publisherName = params.publisher;
+
+	if (!publisherName) {
+		return errorResponse('Missing publisher parameter', 400);
+	}
+
+	try {
+		const result = await listLibraryUseCase.execute();
+		if (!result.ok) {
+			return errorResponse(result.error.message, result.error.status);
+		}
+
+		// Filter by publisher and sort alphabetically
+		const books = result.value.books.filter(
+			(book) => book.publisher === publisherName
+		).sort((a, b) => a.title.localeCompare(b.title));
+		
+		const selfUrl = `/api/opds/publishers/${encodeURIComponent(publisherName)}`;
+
+		const xml = renderAcquisitionFeed(
+			`Books from ${publisherName}`,
+			`urn:sake:opds:publisher:${encodeURIComponent(publisherName)}`,
+			books,
+			selfUrl
+		);
+
+		return new Response(xml, {
+			headers: {
+				'Content-Type': 'application/atom+xml;charset=utf-8'
+			}
+		});
+	} catch (err: unknown) {
+		requestLogger.error({ event: 'opds.publisher.books.failed', error: err }, 'Failed to generate publisher books feed');
+		return errorResponse('Internal Server Error', 500);
+	}
+};

--- a/sake/src/routes/api/opds/publishers/[publisher]/+server.ts
+++ b/sake/src/routes/api/opds/publishers/[publisher]/+server.ts
@@ -1,49 +1,51 @@
-import type { RequestHandler } from '@sveltejs/kit';
-import { requireBasicAuth } from '../../auth';
-import { listLibraryUseCase } from '$lib/server/application/composition';
-import { renderAcquisitionFeed } from '../../feedBuilder';
-import { errorResponse } from '$lib/server/http/api';
-import { getRequestLogger } from '$lib/server/http/requestLogger';
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireBasicAuth } from "../../auth";
+import { listLibraryUseCase } from "$lib/server/application/composition";
+import { renderAcquisitionFeed } from "../../feedBuilder";
+import { errorResponse } from "$lib/server/http/api";
+import { getRequestLogger } from "$lib/server/http/requestLogger";
 
 export const GET: RequestHandler = async (event) => {
-	const authResponse = await requireBasicAuth(event);
-	if (authResponse) return authResponse;
+  const authResponse = await requireBasicAuth(event);
+  if (authResponse) return authResponse;
 
-	const { params, locals } = event;
-	const requestLogger = getRequestLogger(locals);
-	const publisherName = params.publisher;
+  const { params, locals } = event;
+  const requestLogger = getRequestLogger(locals);
+  const publisherName = params.publisher;
 
-	if (!publisherName) {
-		return errorResponse('Missing publisher parameter', 400);
-	}
+  if (!publisherName) {
+    return errorResponse("Missing publisher parameter", 400);
+  }
 
-	try {
-		const result = await listLibraryUseCase.execute();
-		if (!result.ok) {
-			return errorResponse(result.error.message, result.error.status);
-		}
+  try {
+    const result = await listLibraryUseCase.execute();
+    if (!result.ok) {
+      return errorResponse(result.error.message, result.error.status);
+    }
 
-		// Filter by publisher and sort alphabetically
-		const books = result.value.books.filter(
-			(book) => book.publisher === publisherName
-		).sort((a, b) => a.title.localeCompare(b.title));
-		
-		const selfUrl = `/api/opds/publishers/${encodeURIComponent(publisherName)}`;
+    const books = result.value.books
+      .filter((book) => book.publisher === publisherName)
+      .sort((a, b) => a.title.localeCompare(b.title));
 
-		const xml = renderAcquisitionFeed(
-			`Books from ${publisherName}`,
-			`urn:sake:opds:publisher:${encodeURIComponent(publisherName)}`,
-			books,
-			selfUrl
-		);
+    const selfUrl = `/api/opds/publishers/${encodeURIComponent(publisherName)}`;
 
-		return new Response(xml, {
-			headers: {
-				'Content-Type': 'application/atom+xml;charset=utf-8'
-			}
-		});
-	} catch (err: unknown) {
-		requestLogger.error({ event: 'opds.publisher.books.failed', error: err }, 'Failed to generate publisher books feed');
-		return errorResponse('Internal Server Error', 500);
-	}
+    const xml = renderAcquisitionFeed(
+      `Books from ${publisherName}`,
+      `urn:sake:opds:publisher:${encodeURIComponent(publisherName)}`,
+      books,
+      selfUrl,
+    );
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/atom+xml;charset=utf-8",
+      },
+    });
+  } catch (err: unknown) {
+    requestLogger.error(
+      { event: "opds.publisher.books.failed", error: err },
+      "Failed to generate publisher books feed",
+    );
+    return errorResponse("Internal Server Error", 500);
+  }
 };

--- a/sake/src/routes/api/opds/random/+server.ts
+++ b/sake/src/routes/api/opds/random/+server.ts
@@ -1,0 +1,44 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireBasicAuth } from "../auth";
+import { listLibraryUseCase } from "$lib/server/application/composition";
+import { renderAcquisitionFeed } from "../feedBuilder";
+import { errorResponse } from "$lib/server/http/api";
+import { getRequestLogger } from "$lib/server/http/requestLogger";
+
+export const GET: RequestHandler = async (event) => {
+  const authResponse = await requireBasicAuth(event);
+  if (authResponse) return authResponse;
+
+  const { locals, url } = event;
+  const requestLogger = getRequestLogger(locals);
+
+  try {
+    const result = await listLibraryUseCase.execute();
+    if (!result.ok) {
+      return errorResponse(result.error.message, result.error.status);
+    }
+
+    const books = result.value.books.filter(() => Math.random() >= 0.5);
+
+    const selfUrl = `/api/opds/random`;
+
+    const xml = renderAcquisitionFeed(
+      `Random Books`,
+      `urn:sake:opds:random`,
+      books,
+      selfUrl,
+    );
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/atom+xml;charset=utf-8",
+      },
+    });
+  } catch (err: unknown) {
+    requestLogger.error(
+      { event: "opds.random.books.failed", error: err },
+      "Failed to generate random books feed",
+    );
+    return errorResponse("Internal Server Error", 500);
+  }
+};

--- a/sake/src/routes/api/opds/read/+server.ts
+++ b/sake/src/routes/api/opds/read/+server.ts
@@ -1,0 +1,46 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireBasicAuth } from "../auth";
+import { listLibraryUseCase } from "$lib/server/application/composition";
+import { renderAcquisitionFeed } from "../feedBuilder";
+import { errorResponse } from "$lib/server/http/api";
+import { getRequestLogger } from "$lib/server/http/requestLogger";
+
+export const GET: RequestHandler = async (event) => {
+  const authResponse = await requireBasicAuth(event);
+  if (authResponse) return authResponse;
+
+  const { locals, url } = event;
+  const requestLogger = getRequestLogger(locals);
+
+  try {
+    const result = await listLibraryUseCase.execute();
+    if (!result.ok) {
+      return errorResponse(result.error.message, result.error.status);
+    }
+
+    const books = result.value.books
+      .filter((book) => book.read_at !== null)
+      .sort((a, b) => a.title.localeCompare(b.title));
+
+    const selfUrl = `/api/opds/read`;
+
+    const xml = renderAcquisitionFeed(
+      `Read Books`,
+      `urn:sake:opds:read`,
+      books,
+      selfUrl,
+    );
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/atom+xml;charset=utf-8",
+      },
+    });
+  } catch (err: unknown) {
+    requestLogger.error(
+      { event: "opds.read.books.failed", error: err },
+      "Failed to generate read books feed",
+    );
+    return errorResponse("Internal Server Error", 500);
+  }
+};

--- a/sake/src/routes/api/opds/series/+server.ts
+++ b/sake/src/routes/api/opds/series/+server.ts
@@ -1,0 +1,60 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireBasicAuth } from "../auth";
+import { listLibraryUseCase } from "$lib/server/application/composition";
+import { renderNavigationFeed } from "../feedBuilder";
+import { errorResponse } from "$lib/server/http/api";
+import { getRequestLogger } from "$lib/server/http/requestLogger";
+
+export const GET: RequestHandler = async (event) => {
+  const authResponse = await requireBasicAuth(event);
+  if (authResponse) return authResponse;
+
+  const { locals } = event;
+  const requestLogger = getRequestLogger(locals);
+
+  try {
+    const result = await listLibraryUseCase.execute();
+    if (!result.ok) {
+      return errorResponse(result.error.message, result.error.status);
+    }
+
+    const books = result.value.books;
+
+    // Get unique series
+    const seriesSet = new Set<string>();
+    for (const book of books) {
+      if (book.series) {
+        seriesSet.add(book.series);
+      }
+    }
+
+    const seriesList = Array.from(seriesSet).sort();
+
+    const selfUrl = `/api/opds/series`;
+
+    const entries = seriesList.map((series) => ({
+      title: series,
+      id: `urn:sake:opds:series:${encodeURIComponent(series)}`,
+      url: `${encodeURIComponent(series)}`,
+    }));
+
+    const xml = renderNavigationFeed(
+      "Series",
+      "urn:sake:opds:series",
+      entries,
+      selfUrl,
+    );
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/atom+xml;charset=utf-8",
+      },
+    });
+  } catch (err: unknown) {
+    requestLogger.error(
+      { event: "opds.series.failed", error: err },
+      "Failed to generate series feed",
+    );
+    return errorResponse("Internal Server Error", 500);
+  }
+};

--- a/sake/src/routes/api/opds/series/+server.ts
+++ b/sake/src/routes/api/opds/series/+server.ts
@@ -20,7 +20,6 @@ export const GET: RequestHandler = async (event) => {
 
     const books = result.value.books;
 
-    // Get unique series
     const seriesSet = new Set<string>();
     for (const book of books) {
       if (book.series) {

--- a/sake/src/routes/api/opds/series/[series]/+server.ts
+++ b/sake/src/routes/api/opds/series/[series]/+server.ts
@@ -1,0 +1,56 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { requireBasicAuth } from '../../auth';
+import { listLibraryUseCase } from '$lib/server/application/composition';
+import { renderAcquisitionFeed } from '../../feedBuilder';
+import { errorResponse } from '$lib/server/http/api';
+import { getRequestLogger } from '$lib/server/http/requestLogger';
+
+export const GET: RequestHandler = async (event) => {
+	const authResponse = await requireBasicAuth(event);
+	if (authResponse) return authResponse;
+
+	const { params, locals } = event;
+	const requestLogger = getRequestLogger(locals);
+	const seriesName = params.series;
+
+	if (!seriesName) {
+		return errorResponse('Missing series parameter', 400);
+	}
+
+	try {
+		const result = await listLibraryUseCase.execute();
+		if (!result.ok) {
+			return errorResponse(result.error.message, result.error.status);
+		}
+
+		// Filter by series and sort by series_index, then by title
+		const books = result.value.books.filter(
+			(book) => book.series === seriesName
+		).sort((a, b) => {
+			const indexA = a.series_index ?? Number.MAX_VALUE;
+			const indexB = b.series_index ?? Number.MAX_VALUE;
+			if (indexA !== indexB) {
+				return indexA - indexB;
+			}
+			return a.title.localeCompare(b.title);
+		});
+		
+		const selfUrl = `/api/opds/series/${encodeURIComponent(seriesName)}`;
+
+		const xml = renderAcquisitionFeed(
+			`Series: ${seriesName}`,
+			`urn:sake:opds:series:${encodeURIComponent(seriesName)}`,
+			books,
+			selfUrl
+		);
+
+		return new Response(xml, {
+			headers: {
+				'Content-Type': 'application/atom+xml;charset=utf-8'
+			}
+		});
+	} catch (err: unknown) {
+		requestLogger.error({ event: 'opds.series.books.failed', error: err }, 'Failed to generate series books feed');
+		return errorResponse('Internal Server Error', 500);
+	}
+};

--- a/sake/src/routes/api/opds/series/[series]/+server.ts
+++ b/sake/src/routes/api/opds/series/[series]/+server.ts
@@ -1,56 +1,58 @@
-import type { RequestHandler } from '@sveltejs/kit';
-import { requireBasicAuth } from '../../auth';
-import { listLibraryUseCase } from '$lib/server/application/composition';
-import { renderAcquisitionFeed } from '../../feedBuilder';
-import { errorResponse } from '$lib/server/http/api';
-import { getRequestLogger } from '$lib/server/http/requestLogger';
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireBasicAuth } from "../../auth";
+import { listLibraryUseCase } from "$lib/server/application/composition";
+import { renderAcquisitionFeed } from "../../feedBuilder";
+import { errorResponse } from "$lib/server/http/api";
+import { getRequestLogger } from "$lib/server/http/requestLogger";
 
 export const GET: RequestHandler = async (event) => {
-	const authResponse = await requireBasicAuth(event);
-	if (authResponse) return authResponse;
+  const authResponse = await requireBasicAuth(event);
+  if (authResponse) return authResponse;
 
-	const { params, locals } = event;
-	const requestLogger = getRequestLogger(locals);
-	const seriesName = params.series;
+  const { params, locals } = event;
+  const requestLogger = getRequestLogger(locals);
+  const seriesName = params.series;
 
-	if (!seriesName) {
-		return errorResponse('Missing series parameter', 400);
-	}
+  if (!seriesName) {
+    return errorResponse("Missing series parameter", 400);
+  }
 
-	try {
-		const result = await listLibraryUseCase.execute();
-		if (!result.ok) {
-			return errorResponse(result.error.message, result.error.status);
-		}
+  try {
+    const result = await listLibraryUseCase.execute();
+    if (!result.ok) {
+      return errorResponse(result.error.message, result.error.status);
+    }
 
-		// Filter by series and sort by series_index, then by title
-		const books = result.value.books.filter(
-			(book) => book.series === seriesName
-		).sort((a, b) => {
-			const indexA = a.series_index ?? Number.MAX_VALUE;
-			const indexB = b.series_index ?? Number.MAX_VALUE;
-			if (indexA !== indexB) {
-				return indexA - indexB;
-			}
-			return a.title.localeCompare(b.title);
-		});
-		
-		const selfUrl = `/api/opds/series/${encodeURIComponent(seriesName)}`;
+    const books = result.value.books
+      .filter((book) => book.series === seriesName)
+      .sort((a, b) => {
+        const indexA = a.series_index ?? Number.MAX_VALUE;
+        const indexB = b.series_index ?? Number.MAX_VALUE;
+        if (indexA !== indexB) {
+          return indexA - indexB;
+        }
+        return a.title.localeCompare(b.title);
+      });
 
-		const xml = renderAcquisitionFeed(
-			`Series: ${seriesName}`,
-			`urn:sake:opds:series:${encodeURIComponent(seriesName)}`,
-			books,
-			selfUrl
-		);
+    const selfUrl = `/api/opds/series/${encodeURIComponent(seriesName)}`;
 
-		return new Response(xml, {
-			headers: {
-				'Content-Type': 'application/atom+xml;charset=utf-8'
-			}
-		});
-	} catch (err: unknown) {
-		requestLogger.error({ event: 'opds.series.books.failed', error: err }, 'Failed to generate series books feed');
-		return errorResponse('Internal Server Error', 500);
-	}
+    const xml = renderAcquisitionFeed(
+      `Series: ${seriesName}`,
+      `urn:sake:opds:series:${encodeURIComponent(seriesName)}`,
+      books,
+      selfUrl,
+    );
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/atom+xml;charset=utf-8",
+      },
+    });
+  } catch (err: unknown) {
+    requestLogger.error(
+      { event: "opds.series.books.failed", error: err },
+      "Failed to generate series books feed",
+    );
+    return errorResponse("Internal Server Error", 500);
+  }
 };

--- a/sake/src/routes/api/opds/shelves/+server.ts
+++ b/sake/src/routes/api/opds/shelves/+server.ts
@@ -1,0 +1,52 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireBasicAuth } from "../auth";
+import { listShelvesUseCase } from "$lib/server/application/composition";
+import { renderNavigationFeed } from "../feedBuilder";
+import { errorResponse } from "$lib/server/http/api";
+import { getRequestLogger } from "$lib/server/http/requestLogger";
+
+export const GET: RequestHandler = async (event) => {
+  const authResponse = await requireBasicAuth(event);
+  if (authResponse) return authResponse;
+
+  const { locals, url } = event;
+  const requestLogger = getRequestLogger(locals);
+
+  try {
+    const result = await listShelvesUseCase.execute();
+    if (!result.ok) {
+      return errorResponse(result.error.message, result.error.status);
+    }
+
+    const shelves = result.value.shelves.sort(
+      (a, b) => a.sortOrder - b.sortOrder,
+    );
+
+    const selfUrl = `/api/opds/shelves`;
+
+    const entries = shelves.map((shelf) => ({
+      title: shelf.name,
+      id: `urn:sake:opds:shelf:${shelf.id}`,
+      url: `${shelf.id}`,
+    }));
+
+    const xml = renderNavigationFeed(
+      "Shelves",
+      "urn:sake:opds:shelves",
+      entries,
+      selfUrl,
+    );
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/atom+xml;charset=utf-8",
+      },
+    });
+  } catch (err: unknown) {
+    requestLogger.error(
+      { event: "opds.shelves.failed", error: err },
+      "Failed to generate shelves feed",
+    );
+    return errorResponse("Internal Server Error", 500);
+  }
+};

--- a/sake/src/routes/api/opds/shelves/[id]/+server.ts
+++ b/sake/src/routes/api/opds/shelves/[id]/+server.ts
@@ -1,0 +1,64 @@
+import type { RequestHandler } from '@sveltejs/kit';
+import { requireBasicAuth } from '../../auth';
+import { listLibraryUseCase, listShelvesUseCase } from '$lib/server/application/composition';
+import { renderAcquisitionFeed } from '../../feedBuilder';
+import { errorResponse } from '$lib/server/http/api';
+import { getRequestLogger } from '$lib/server/http/requestLogger';
+
+export const GET: RequestHandler = async (event) => {
+	const authResponse = await requireBasicAuth(event);
+	if (authResponse) return authResponse;
+
+	const { params, locals, url } = event;
+	const requestLogger = getRequestLogger(locals);
+	const shelfIdParam = params.id;
+
+	if (!shelfIdParam) {
+		return errorResponse('Missing shelf ID parameter', 400);
+	}
+
+	const shelfId = parseInt(shelfIdParam, 10);
+	if (isNaN(shelfId)) {
+		return errorResponse('Invalid shelf ID parameter', 400);
+	}
+
+	try {
+		// First get the shelf name to display in the title
+		const shelvesResult = await listShelvesUseCase.execute();
+		if (!shelvesResult.ok) {
+			return errorResponse(shelvesResult.error.message, shelvesResult.error.status);
+		}
+
+		const shelf = shelvesResult.value.shelves.find((s) => s.id === shelfId);
+		if (!shelf) {
+			return errorResponse('Shelf not found', 404);
+		}
+
+		const result = await listLibraryUseCase.execute();
+		if (!result.ok) {
+			return errorResponse(result.error.message, result.error.status);
+		}
+
+		const books = result.value.books.filter(
+			(book) => book.shelfIds.includes(shelfId)
+		).sort((a, b) => a.title.localeCompare(b.title));
+		
+		const selfUrl = `/api/opds/shelves/${shelfId}`;
+
+		const xml = renderAcquisitionFeed(
+			`Shelf: ${shelf.name}`,
+			`urn:sake:opds:shelf:${shelfId}`,
+			books,
+			selfUrl
+		);
+
+		return new Response(xml, {
+			headers: {
+				'Content-Type': 'application/atom+xml;charset=utf-8'
+			}
+		});
+	} catch (err: unknown) {
+		requestLogger.error({ event: 'opds.shelf.books.failed', error: err }, 'Failed to generate shelf books feed');
+		return errorResponse('Internal Server Error', 500);
+	}
+};

--- a/sake/src/routes/api/opds/shelves/[id]/+server.ts
+++ b/sake/src/routes/api/opds/shelves/[id]/+server.ts
@@ -1,64 +1,72 @@
-import type { RequestHandler } from '@sveltejs/kit';
-import { requireBasicAuth } from '../../auth';
-import { listLibraryUseCase, listShelvesUseCase } from '$lib/server/application/composition';
-import { renderAcquisitionFeed } from '../../feedBuilder';
-import { errorResponse } from '$lib/server/http/api';
-import { getRequestLogger } from '$lib/server/http/requestLogger';
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireBasicAuth } from "../../auth";
+import {
+  listLibraryUseCase,
+  listShelvesUseCase,
+} from "$lib/server/application/composition";
+import { renderAcquisitionFeed } from "../../feedBuilder";
+import { errorResponse } from "$lib/server/http/api";
+import { getRequestLogger } from "$lib/server/http/requestLogger";
 
 export const GET: RequestHandler = async (event) => {
-	const authResponse = await requireBasicAuth(event);
-	if (authResponse) return authResponse;
+  const authResponse = await requireBasicAuth(event);
+  if (authResponse) return authResponse;
 
-	const { params, locals, url } = event;
-	const requestLogger = getRequestLogger(locals);
-	const shelfIdParam = params.id;
+  const { params, locals, url } = event;
+  const requestLogger = getRequestLogger(locals);
+  const shelfIdParam = params.id;
 
-	if (!shelfIdParam) {
-		return errorResponse('Missing shelf ID parameter', 400);
-	}
+  if (!shelfIdParam) {
+    return errorResponse("Missing shelf ID parameter", 400);
+  }
 
-	const shelfId = parseInt(shelfIdParam, 10);
-	if (isNaN(shelfId)) {
-		return errorResponse('Invalid shelf ID parameter', 400);
-	}
+  const shelfId = parseInt(shelfIdParam, 10);
+  if (isNaN(shelfId)) {
+    return errorResponse("Invalid shelf ID parameter", 400);
+  }
 
-	try {
-		// First get the shelf name to display in the title
-		const shelvesResult = await listShelvesUseCase.execute();
-		if (!shelvesResult.ok) {
-			return errorResponse(shelvesResult.error.message, shelvesResult.error.status);
-		}
+  try {
+    const shelvesResult = await listShelvesUseCase.execute();
+    if (!shelvesResult.ok) {
+      return errorResponse(
+        shelvesResult.error.message,
+        shelvesResult.error.status,
+      );
+    }
 
-		const shelf = shelvesResult.value.shelves.find((s) => s.id === shelfId);
-		if (!shelf) {
-			return errorResponse('Shelf not found', 404);
-		}
+    const shelf = shelvesResult.value.shelves.find((s) => s.id === shelfId);
+    if (!shelf) {
+      return errorResponse("Shelf not found", 404);
+    }
 
-		const result = await listLibraryUseCase.execute();
-		if (!result.ok) {
-			return errorResponse(result.error.message, result.error.status);
-		}
+    const result = await listLibraryUseCase.execute();
+    if (!result.ok) {
+      return errorResponse(result.error.message, result.error.status);
+    }
 
-		const books = result.value.books.filter(
-			(book) => book.shelfIds.includes(shelfId)
-		).sort((a, b) => a.title.localeCompare(b.title));
-		
-		const selfUrl = `/api/opds/shelves/${shelfId}`;
+    const books = result.value.books
+      .filter((book) => book.shelfIds.includes(shelfId))
+      .sort((a, b) => a.title.localeCompare(b.title));
 
-		const xml = renderAcquisitionFeed(
-			`Shelf: ${shelf.name}`,
-			`urn:sake:opds:shelf:${shelfId}`,
-			books,
-			selfUrl
-		);
+    const selfUrl = `/api/opds/shelves/${shelfId}`;
 
-		return new Response(xml, {
-			headers: {
-				'Content-Type': 'application/atom+xml;charset=utf-8'
-			}
-		});
-	} catch (err: unknown) {
-		requestLogger.error({ event: 'opds.shelf.books.failed', error: err }, 'Failed to generate shelf books feed');
-		return errorResponse('Internal Server Error', 500);
-	}
+    const xml = renderAcquisitionFeed(
+      `Shelf: ${shelf.name}`,
+      `urn:sake:opds:shelf:${shelfId}`,
+      books,
+      selfUrl,
+    );
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/atom+xml;charset=utf-8",
+      },
+    });
+  } catch (err: unknown) {
+    requestLogger.error(
+      { event: "opds.shelf.books.failed", error: err },
+      "Failed to generate shelf books feed",
+    );
+    return errorResponse("Internal Server Error", 500);
+  }
 };

--- a/sake/src/routes/api/opds/unread/+server.ts
+++ b/sake/src/routes/api/opds/unread/+server.ts
@@ -1,0 +1,46 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { requireBasicAuth } from "../auth";
+import { listLibraryUseCase } from "$lib/server/application/composition";
+import { renderAcquisitionFeed } from "../feedBuilder";
+import { errorResponse } from "$lib/server/http/api";
+import { getRequestLogger } from "$lib/server/http/requestLogger";
+
+export const GET: RequestHandler = async (event) => {
+  const authResponse = await requireBasicAuth(event);
+  if (authResponse) return authResponse;
+
+  const { locals, url } = event;
+  const requestLogger = getRequestLogger(locals);
+
+  try {
+    const result = await listLibraryUseCase.execute();
+    if (!result.ok) {
+      return errorResponse(result.error.message, result.error.status);
+    }
+
+    const books = result.value.books
+      .filter((book) => book.read_at === null)
+      .sort((a, b) => a.title.localeCompare(b.title));
+
+    const selfUrl = `/api/opds/unread`;
+
+    const xml = renderAcquisitionFeed(
+      `Unread Books`,
+      `urn:sake:opds:unread`,
+      books,
+      selfUrl,
+    );
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/atom+xml;charset=utf-8",
+      },
+    });
+  } catch (err: unknown) {
+    requestLogger.error(
+      { event: "opds.unread.books.failed", error: err },
+      "Failed to generate unread books feed",
+    );
+    return errorResponse("Internal Server Error", 500);
+  }
+};


### PR DESCRIPTION
This PR introduces a fully functional OPDS 1.2 catalog to Sake, allowing users to seamlessly browse and download their library directly from compatible e-readers and apps (e.g., KOReader, Moon+ Reader, PocketBook, etc.). 

Since OPDS clients traditionally rely on HTTP Basic Authentication rather than custom headers or session cookies, the OPDS routes have been securely isolated to use Basic Auth.

## Key Features
* **OPDS 1.2 Compliant XML Feeds:** Strict adherence to Atom XML structures for both Navigation and Acquisition feeds.
* **Basic Authentication:** Users can log in to the OPDS catalog using their standard Sake username and password.
* **Comprehensive Navigation:**
  * **All Books (Alphabetical):** Complete library catalog sorted A-Z.
  * **Random Books:** Subsection of library, in random order for discovery.
  * **Read Books**
  * **Unread Books**
  * **Authors**
  * **Series:** Books within a series are smartly sorted by `series_index` first, then alphabetically by title.
  * **Publishers**
  * **Languages**
  * **Shelves**
* **Secure Downloads:** Books and covers are served through dedicated OPDS endpoints (`/api/opds/download/[title]` and `/api/opds/covers/[fileName]`), ensuring that media acquisition remains protected behind the same Basic Auth wall as the catalog itself.

## Implementation Details
1. **Auth Bypass & Middleware:** Modified `isPublicApiRoute` in `src/lib/server/auth/requestAccess.ts` to allow `/api/opds` to bypass the default session/API Key interceptors. Created a custom `requireBasicAuth` middleware (`src/routes/api/opds/auth.ts`) utilizing the existing `verifyPassword` service and `userRepository`.
2. **Feed Builder:** Abstracted XML generation into `src/routes/api/opds/feedBuilder.ts` with `renderNavigationFeed` and `renderAcquisitionFeed` to ensure consistent formatting, MIME type handling, and XML character escaping.
3. **Endpoint Architecture:** Leveraged SvelteKit dynamic routing (`+server.ts`) to dynamically query `listLibraryUseCase` and `listShelvesUseCase`, filter results in-memory, and return the appropriate Atom XML feeds.

## Testing
- Verified successful authentication flow using standard HTTP Basic Auth headers.
- Verified all XML feeds are correctly formed and correctly handle special characters in titles/authors/descriptions.
- Verified correct sorting logic (especially for Series indices).
- Passed all internal type checks (`svelte-check`).
- Tested on KOReaders OPDS client