### PR TITLE
feat: Make Sake quick action in SimpleUI download new books. 

### DIFF
--- a/koreaderPlugins/sake.koplugin/main.lua
+++ b/koreaderPlugins/sake.koplugin/main.lua
@@ -916,4 +916,8 @@ function Sake:onReaderReady()
     self:runProgressSync({ silent = true, silent_summary = true })
 end
 
+function Sake:onSake()
+    self.bookSync:syncNow()
+end
+
 return Sake


### PR DESCRIPTION
When using SimpleUI (https://github.com/doctorhetfield-cmd/simpleui.koplugin), Sake shows as an available Quick Action under System Actions but does nothing when configured. 

This PR changes that behavior to download new books from Sake. 

Claude's description: 
The registered Dispatcher action (event="Sake") had no corresponding handler, so triggering it did nothing. Add onSake() to call syncNow(). 